### PR TITLE
Update to v1.14.1 and revert Freedesktop runtime version

### DIFF
--- a/com.github.tmewett.BrogueCE.json
+++ b/com.github.tmewett.BrogueCE.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.tmewett.BrogueCE",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "brogue",
     "finish-args": [
@@ -30,7 +30,7 @@
                 {
                     "type": "git",
                     "url" : "https://github.com/tmewett/BrogueCE.git",
-                    "tag":  "v1.14"
+                    "tag":  "v1.14.1"
                 },
                 {
                     "type": "script",

--- a/com.github.tmewett.BrogueCE.metainfo.xml
+++ b/com.github.tmewett.BrogueCE.metainfo.xml
@@ -4,6 +4,7 @@
     <launchable type="desktop-id">com.github.tmewett.BrogueCE.desktop</launchable>
     <name>BrogueCE</name>
     <releases>
+      <release version="1.14.1" date="2024-08-31"></release>
       <release version="1.14" date="2024-08-04"></release>
       <release version="1.13" date="2023-10-05"></release>
       <release version="1.12" date="2023-02-02"></release>


### PR DESCRIPTION
Reverting the Freedesktop runtime version to 22.08 _should_ fix the [input issues on Wayland](https://github.com/flathub/com.github.tmewett.BrogueCE/issues/8). I'm not putting a `Closes #8` because I am currently not able to verify if this actually fixes it. In any case, using 22.08 should be fine.

Eventually, runtime version 24.08 should be tried as well to see if it's maybe also fixed there, but going back to 22.08 is the safer bet for now (that won't potentially break anything else).

See also [these Reddit comments](https://www.reddit.com/r/brogueforum/comments/yco8h6/comment/lqwtck6/) which likely describe the same issue.