### PR TITLE
Update Freedesktop runtime to 24.08

### DIFF
--- a/com.github.tmewett.BrogueCE.json
+++ b/com.github.tmewett.BrogueCE.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.tmewett.BrogueCE",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "brogue",
     "finish-args": [


### PR DESCRIPTION
This updates the Freedesktop runtime to 24.08 to replace the EOL 22.08 that was reverted to via #20 to fix input issues on some Wayland compositors (see #8).

It will also get rid of this warning that's now displayed on Flathub:

<img width="261" alt="image" src="https://github.com/user-attachments/assets/2e91ea61-1b5b-432d-a994-34f4a0002bcc">

~~Before this gets merged it should be confirmed that it doesn't cause the same input issues (as 23.08 did).~~

[Here](https://github.com/flathub/com.github.tmewett.BrogueCE/issues/8#issuecomment-2499234676) is feedback from a user who ran the test build from this PR and confirmed that the mentioned Wayland input issues are not present on Gnome Wayland.

---

I was also able to confirm the issues are not present in an embedded Gamescope session, i.e., on Steam Deck (apologies for the photo, this was just a lot quicker than taking a proper screenshot and transferring it to my PC):

![image](https://github.com/user-attachments/assets/801ffd23-af5e-410d-bcb8-e257fec55a5a)

In case someone is not familiar with the Steam Deck, the radial menu you can see in the bottom left emulates keyboard inputs for the displayed letters, so this should be a valid way to test if the issue is present or not, even without a physical keyboard.

There here have been [reports on Reddit](https://www.reddit.com/r/brogueforum/comments/yco8h6/comment/lqwtck6/) that the Wayland input issues existed there too (with Freedesktop runtime 23.08, before we reverted to using 22.08).

---

I think with this it should be safe to say that updating the runtime to 24.08 should be fine, thus: closes #8.